### PR TITLE
Added additional error info when testing, custom events, and "Do nothing" action

### DIFF
--- a/octoprint_filamentsensorsimplified/__init__.py
+++ b/octoprint_filamentsensorsimplified/__init__.py
@@ -418,6 +418,9 @@ class Filament_sensor_simplifiedPlugin(octoprint.plugin.StartupPlugin,
             self.paused_for_user = False
             self.printing = True
 
+            if self.setting_cmd_action is 2: # "Do nothing" cmd option
+                return
+
             # print started with no filament present
             if event is Events.PRINT_STARTED and self.plugin_enabled(self.setting_pin):
                 self._logger.info("Starting print.")

--- a/octoprint_filamentsensorsimplified/static/js/filamentsensorsimplified.js
+++ b/octoprint_filamentsensorsimplified/static/js/filamentsensorsimplified.js
@@ -70,9 +70,10 @@ $(function () {
                             self.testSensorResult('<i class="fas icon-warning-sign fa-exclamation-triangle"></i> The pin selected is power, ground or out of range pin number, choose other pin');
                         }
                     },
-                    error: function () {
+                    error: function (jqXHR) {
+                        console.log(JSON.stringify(jqXHR));
                         $("#filamentsensorsimplified_settings_testResult").addClass("alert-error");
-                        self.testSensorResult('<i class="fas icon-warning-sign fa-exclamation-triangle"></i> There was an error :(');
+                        self.testSensorResult('<i class="fas icon-warning-sign fa-exclamation-triangle"></i> There was an error &#128542 (check browser console for details)');
                     },
                     success: function (result) {
                         if (result.triggered === 0) {

--- a/octoprint_filamentsensorsimplified/templates/filamentsensorsimplified_settings.jinja2
+++ b/octoprint_filamentsensorsimplified/templates/filamentsensorsimplified_settings.jinja2
@@ -76,15 +76,18 @@
             <select data-bind="value: settingsViewModel.settings.plugins.filamentsensorsimplified.cmd_action, disable:printing" required>
                 <option value=0>{{ _('Send G-code') }}</option>
                 <option value=1>{{ _('OctoPrint pause') }}</option>
+                <option value=2>{{ _('Do nothing') }}</option>
             </select>
         </div>
 
         <br/>
-        <label class="control-label" for="filamentsensorsimplified_settings_commandInput">{{ _('G-code') }}</label>
-        <div class="controls">
-            <input id="filamentsensorsimplified_settings_commandInput" type="text" class="input-large" data-bind="value: settingsViewModel.settings.plugins.filamentsensorsimplified.g_code, disable:printing">
-            <span class="margin-top10 help-block" data-bind="visible: settingsViewModel.settings.plugins.filamentsensorsimplified.cmd_action() == 0">Which G-code will be sent to printer on filament runout.</span>
-            <span class="margin-top10 help-block" data-bind="visible: settingsViewModel.settings.plugins.filamentsensorsimplified.cmd_action() == 1">Which G-code will be sent to printer before pausing print.</span>
+        <div data-bind="visible: settingsViewModel.settings.plugins.filamentsensorsimplified.cmd_action() != 2">
+            <label class="control-label" for="filamentsensorsimplified_settings_commandInput">{{ _('G-code') }}</label>
+            <div class="controls">
+                <input id="filamentsensorsimplified_settings_commandInput" type="text" class="input-large" data-bind="value: settingsViewModel.settings.plugins.filamentsensorsimplified.g_code, disable:printing">
+                <span class="margin-top10 help-block" data-bind="visible: settingsViewModel.settings.plugins.filamentsensorsimplified.cmd_action() == 0">Which G-code will be sent to printer on filament runout.</span>
+                <span class="margin-top10 help-block" data-bind="visible: settingsViewModel.settings.plugins.filamentsensorsimplified.cmd_action() == 1">Which G-code will be sent to printer before pausing print.</span>
+            </div>
         </div>
     </div>
 


### PR DESCRIPTION
This PR adds 3 small changes:

- Additional info (via the browser's console) when clicking "Test sensor"
- Firing custom events when the sensor is triggered (useful for plugins like https://github.com/tjjfvi/OctoPrint-IFTTT that allow you to subscribe to custom events)
- A 'Do Nothing' action option to perform when the sensor is triggered (useful for users who only want the navbar status & popup  notification or for users who will use the custom events mentioned above to create their own action/notification)